### PR TITLE
Fixes Kane.Topic.create/1 returning a GCP error

### DIFF
--- a/lib/kane/client.ex
+++ b/lib/kane/client.ex
@@ -14,14 +14,14 @@ defmodule Kane.Client do
   @spec put(binary, any) :: Success.t | Error.t
   def put(path, data \\ "") do
     url(path)
-    |> HTTPoison.put(Poison.encode!(data), [auth_header])
+    |> HTTPoison.put(encode!(data), [auth_header])
     |> handle_response
   end
 
   @spec post(binary, any) :: Success.t | Error.t
   def post(path, data) do
     url(path)
-    |> HTTPoison.post(Poison.encode!(data), [auth_header])
+    |> HTTPoison.post(encode!(data), [auth_header])
     |> handle_response
   end
 
@@ -52,4 +52,7 @@ defmodule Kane.Client do
         {:error, response.body, err}
     end
   end
+
+  defp encode!(""), do: ""
+  defp encode!(data), do: Poison.encode!(data)
 end


### PR DESCRIPTION
When calling Kane.Topic.create/1 I get the following GCP error:

```
{
  "error": {
    "code": 400,
    "message": "Invalid JSON payload received. Unknown name \\\"\\\": Root element must be a message.",
    "status": "INVALID_ARGUMENT",
    "details": [
      {
        "@type": "type.googleapis.com/google.rpc.BadRequest",
        "fieldViolations": [
          {
            "description": "Invalid JSON payload received. Unknown name \\\"\\\": Root element must be a message."
          }
        ]
      }
    ]
  }
}
```

This was due to the payload on the HTTP request body not being empty, but instead this string: `\"\"`, which was generated by the Poison.encode!/1 function being used with an empty string, i.e.:

```
iex(1)> Poison.encode!("")
"\"\""
```

My solution for this issue is to only use Poison.encode!/1 when the data being passed in is not an empty string. After doing this Kane.Topic.create/1 works as expected.