### PR TITLE
Fix for missing message attributes

### DIFF
--- a/lib/kane/message.ex
+++ b/lib/kane/message.ex
@@ -74,8 +74,8 @@ defmodule Kane.Message do
     message
   end
 
-  def from_subscription(%{"ackId" => ack, "message" => %{"data" => data, "publishTime" => time, "messageId" => id}}=mess) do
-    attr = Map.get(mess, "attributes", %{})
+  def from_subscription(%{"ackId" => ack, "message" => %{"data" => data, "publishTime" => time, "messageId" => id} = message }) do
+    attr = Map.get(message, "attributes", %{})
     {:ok, %__MODULE__{
       id: id,
       publish_time: time,

--- a/test/kane/message_test.exs
+++ b/test/kane/message_test.exs
@@ -75,16 +75,18 @@ defmodule Kane.MessageTest do
     data= "eyJoZWxsbyI6IndvcmxkIn0="
     decoded = data |> Base.decode64!
     time= "2016-01-24T03:07:33.195Z"
+    attributes = %{ key: "123" }
 
     assert {:ok,
       %Message{ id:     ^id,
                 ack_id: ^ack,
                 publish_time: ^time,
                 data:  ^decoded,
-                attributes: %{}
+                attributes: ^attributes
       }} = Message.from_subscription(%{"ackId" => ack,
                                         "message" =>
                                         %{"data" => data,
+                                          "attributes" => attributes,
                                         "messageId" => id,
                                         "publishTime" => time}})
   end


### PR DESCRIPTION
Incoming messages didn't include message attributes. This PR fixes that. 