### PR TITLE
Make type spec for Kane.Message struct more permissive

### DIFF
--- a/lib/kane/client/error.ex
+++ b/lib/kane/client/error.ex
@@ -1,3 +1,3 @@
 defmodule Response.Error do
-  @type t :: {:error, binary, {:error, HTTPoison.Error.t}}
+  @type t :: {:error, binary, {:error, HTTPoison.Error.t} | integer()}
 end

--- a/lib/kane/message.ex
+++ b/lib/kane/message.ex
@@ -3,11 +3,11 @@ defmodule Kane.Message do
   alias Kane.Client.Response.Error
 
   @type t :: %__MODULE__{
-    id: String.t,
+    id: String.t | nil,
     attributes: Map.t,
     data: any,
-    ack_id: String.t,
-    publish_time: String.t
+    ack_id: String.t | nil,
+    publish_time: String.t | nil
   }
 
   defstruct id: nil, attributes: %{}, data: nil, ack_id: nil, publish_time: nil


### PR DESCRIPTION
The type spec for the Kane.Message struct required `id`, `ack_id`, and `publish_time` to be of type String.t. However, the default value for these fields is `nil`, which is not of type String.t. This caused
Dialyzer errors whenever creating new messages that used the default values for these fields. By changing the type specs for these fields to allow for `nil`, these Dialyzer errors are resolved.

Also fixed the type spec for `Response.Error` to include the case where the error code is an integer.