### PR TITLE
"data" is optional in PubsubMessage

### DIFF
--- a/lib/kane/message.ex
+++ b/lib/kane/message.ex
@@ -74,13 +74,18 @@ defmodule Kane.Message do
     message
   end
 
-  def from_subscription(%{"ackId" => ack, "message" => %{"data" => data, "publishTime" => time, "messageId" => id} = message }) do
+  def from_subscription(%{"ackId" => ack, "message" => %{"publishTime" => time, "messageId" => id} = message }) do
     attr = Map.get(message, "attributes", %{})
+    data = case Map.get(message, "data", nil) do
+             nil -> nil
+             actual_data -> Base.decode64!(actual_data)
+           end
+
     {:ok, %__MODULE__{
       id: id,
       publish_time: time,
       ack_id: ack,
-      data: data |> Base.decode64!,
+      data: data,
       attributes: attr
     }}
   end


### PR DESCRIPTION
> The message payload must not be empty; it must contain either a non-empty data field, or at least one attribute.

From [official doc](https://cloud.google.com/pubsub/docs/reference/rest/v1/PubsubMessage)

Before the change: (removed our actual message)

```
iex(6)> Kane.Subscription.pull(subscription)
** (FunctionClauseError) no function clause matching in Kane.Message.from_subscription/1

    The following arguments were given to Kane.Message.from_subscription/1:

        # 1
        %{"ackId" => "XkASTDYLRElTK0MLKlgRTgQhIT4wPkVTRFAGFixdRkhRNxkIaFEOT14jPzUgKEURAQgUBXx9cVxSdV5eGgdRDRlyfGQgOQ8aCQFAV3lVUhENem1cVzhQCBl0fWN0aV4TBwFFWn93ppK8qshtZho9XxJLLD5-PT5FQQ",
      "message" => %{"attributes" => %{"sys:action" => "xyz"},
        "messageId" => "150602134063091",
        "publishTime" => "2017-10-02T16:43:50.719Z"}}

    Attempted function clauses (showing 1 out of 1):

        def from_subscription(%{"ackId" => ack, "message" => %{"data" => data, "publishTime" => time, "messageId" => id} = message})

    (kane) deps/kane/lib/kane/message.ex:77: Kane.Message.from_subscription/1
    (kane) deps/kane/lib/kane/message.ex:73: Kane.Message.from_subscription!/1
    (elixir) lib/enum.ex:1270: Enum."-map/2-lists^map/1-0-"/2
    (kane) lib/kane/subscription.ex:41: Kane.Subscription.pull/2
```

After:

```
iex(4)> Kane.Subscription.pull(subscription)
{:ok,
 [%Kane.Message{ack_id: "RUFeQBJMNgpESVMrQwsqWBFOBCEhPjA-RVNEUAYWLF1GSFE3GQhoUQ5PXiM_NSAoRRMLUxNRXHYcShBtM1x1B1ENGHcoNSNsUxcHUEZZeVVbCTxofmN0AlELHnR4aHFuUxoJBkN7_OSute1XZhg9XBJLLD5-PT8",
   attributes: %{"sys:action" => "xyz",
     }, data: nil,
   id: "150676594499846", publish_time: "2017-10-02T23:30:00.835Z"}]}
```