### PR TITLE
Add control over `returnImmediately` parameter of subscription pull

### DIFF
--- a/lib/kane/client.ex
+++ b/lib/kane/client.ex
@@ -2,29 +2,29 @@ defmodule Kane.Client do
   alias Response.Success
   alias Response.Error
 
-  @spec get(binary) :: Success.t() | Error.t()
-  def get(path), do: call(:get, path)
+  @spec get(binary, keyword) :: Success.t() | Error.t()
+  def get(path, options \\ []), do: call(:get, path, options)
 
-  @spec put(binary, any) :: Success.t() | Error.t()
-  def put(path, data \\ ""), do: call(:put, path, data)
+  @spec put(binary, any, keyword) :: Success.t() | Error.t()
+  def put(path, data \\ "", options \\ []), do: call(:put, path, data, options)
 
-  @spec post(binary, any) :: Success.t() | Error.t()
-  def post(path, data), do: call(:post, path, data)
+  @spec post(binary, any, keyword) :: Success.t() | Error.t()
+  def post(path, data, options \\ []), do: call(:post, path, data, options)
 
-  @spec delete(binary) :: Success.t() | Error.t()
-  def delete(path), do: call(:delete, path)
+  @spec delete(binary, keyword) :: Success.t() | Error.t()
+  def delete(path, options \\ []), do: call(:delete, path, options)
 
-  defp call(method, path) do
+  defp call(method, path, options) do
     headers = [auth_header()]
 
-    apply(HTTPoison, method, [url(path), headers])
+    apply(HTTPoison, method, [url(path), headers, options])
     |> handle_response
   end
 
-  defp call(method, path, data) do
+  defp call(method, path, data, options) do
     headers = [auth_header(), {"content-type", "application/json"}]
 
-    apply(HTTPoison, method, [url(path), encode!(data), headers])
+    apply(HTTPoison, method, [url(path), encode!(data), headers, options])
     |> handle_response
   end
 

--- a/lib/kane/subscription.ex
+++ b/lib/kane/subscription.ex
@@ -61,6 +61,27 @@ defmodule Kane.Subscription do
     end
   end
 
+  def stream(%__MODULE__{} = sub, options \\ []) do
+    options = Keyword.put(options, :return_immediately, false)
+
+    Stream.resource(
+      fn -> :ok end,
+      fn acc ->
+        case pull(sub, options) do
+          {:ok, messages} ->
+            {messages, acc}
+
+          err ->
+            {:halt, err}
+        end
+      end,
+      fn
+        :ok -> nil
+        err -> throw(err)
+      end
+    )
+  end
+
   def ack(%__MODULE__{} = sub, messages) when is_list(messages) do
     data = %{"ackIds" => Enum.map(messages, fn m -> m.ack_id end)}
 


### PR DESCRIPTION
Hey @peburrows,

I saw #9 and I thought it would be a good first contribution to the project.

It slightly changes the function interface (but it still keeps the old interface as well). From now on you can call `Kane.Subscription.pull` with subscription and options (kw list) as a second argument. Expected arguments are `max_messages` and `return_immediately`. Both are optional, first defaults to `100` second to  `true`.

I need this since I would like to build GenServer that would ack as a subscription consumer. I have an idea that could be a good extension to your project. What do you think about having module `Kane.Consumer` that could be used like:
```
defmodule MyConsumer do
  use Kane.Consumer

  def handle_messages(messages, state) do
    case process(message) do
      :ok -> {:ack, state}
      :error -> {:noack, state}
    end
  end
end

MyConsumer.start_link(topic: "my-topic", name: "subscription_name", max_messages: 100)
```