### PR TITLE
fix: Dont send Acks when messages is empty

### DIFF
--- a/lib/kane/subscription.ex
+++ b/lib/kane/subscription.ex
@@ -82,6 +82,8 @@ defmodule Kane.Subscription do
     )
   end
 
+  def ack(%__MODULE__{}, []), do: :ok
+
   def ack(%__MODULE__{} = sub, messages) when is_list(messages) do
     data = %{"ackIds" => Enum.map(messages, fn m -> m.ack_id end)}
 

--- a/test/kane/subscription_test.exs
+++ b/test/kane/subscription_test.exs
@@ -205,6 +205,11 @@ defmodule Kane.SubscriptionTest do
     refute_received :subscription_pull
   end
 
+  test "no acknowledgement when no messages given" do
+    # This implicitly tests that ByPass does not receive any request
+    assert :ok == Subscription.ack(%Subscription{name: "ack-my-sub"}, [])
+  end
+
   test "acknowledging a message", %{bypass: bypass} do
     Bypass.expect(bypass, fn conn ->
       assert conn.method == "POST"


### PR DESCRIPTION
We had a  hidden error in our Service, where we used `ack` every time with the result of `pull`, which led to many useless API calls and errors we didn't saw.

I guess this is not really a breaking change and a more reasonable approach to acknowledging an empty list of messages.