### PR TITLE
Add support for multiple accounts

### DIFF
--- a/test/kane/topic_test.exs
+++ b/test/kane/topic_test.exs
@@ -12,6 +12,11 @@ defmodule Kane.TopicTest do
   test "getting full name", %{project: project} do
     name = "my-topic"
     assert "projects/#{project}/topics/#{name}" == %Topic{name: name} |> Topic.full_name()
+
+    assert "projects/whatever/topics/full" ==
+             %Topic{name: {"whatever", "full"}} |> Topic.full_name()
+
+    assert "projects/whatever/topics/mine" == Topic.full_name("projects/whatever/topics/mine")
   end
 
   test "successfully creating a topic", %{bypass: bypass} do

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -2,7 +2,7 @@ ExUnit.start()
 Application.ensure_all_started(:bypass)
 
 defmodule Kane.TestToken do
-  def for_scope(scope) do
+  def for_scope(scope, _sub \\ nil) do
     {:ok,
      %Goth.Token{
        scope: scope,


### PR DESCRIPTION
The project can now be specified on a topic or subscription, and Kane.Client calls now accept :account and :sub options that will be passed through to `Goth.Token.for_scope/2` when retrieving a token