### PR TITLE
Use encode_to_iodata!

### DIFF
--- a/lib/kane/client.ex
+++ b/lib/kane/client.ex
@@ -54,5 +54,5 @@ defmodule Kane.Client do
   end
 
   defp encode!(""), do: ""
-  defp encode!(data), do: Jason.encode!(data)
+  defp encode!(data), do: Jason.encode_to_iodata!(data)
 end


### PR DESCRIPTION
HTTPoison accepts iodata as body and generally passing iodata to IO operations is more efficient.

Reference: https://hexdocs.pm/jason/Jason.html#encode_to_iodata/2